### PR TITLE
Update CREATE-TABLE.md

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE.md
+++ b/i18n/zh-CN/docusaurus-plugin-content-docs/version-2.1/sql-manual/sql-statements/Data-Definition-Statements/Create/CREATE-TABLE.md
@@ -129,6 +129,7 @@ distribution_desc
   * `on update current_timestamp`
 
         是否在该行有列更新时将该列的值更新为当前时间 (`current_timestamp`)。该特性只能在开启了 Merge-on-Write 的 Unique 表上使用，开启了这个特性的列必须声明默认值，且默认值必须为 `current_timestamp`。如果此处声明了时间戳的精度，则该列默认值中的时间戳精度必须与该处的时间戳精度相同。
+    > 备注：经测试 doris 2.1.6 不支持使用alter语法新增使用`on update current_timestamp(6)`特性的列。
 
       
   示例：


### PR DESCRIPTION
增加on update current_timestamp(6)的alter语法测试备注

# Versions 

- [ ] dev
- [ ] 3.0
- [ √ ] 2.1
- [ ] 2.0

# Languages

- [ √ ] Chinese
- [ ] English

# 测试内容
## 测试代码
```
drop table dws.table_hash;
CREATE TABLE dws.table_hash
(
    k1 BIGINT,
    k2 LARGEINT,
    v1 VARCHAR(20),
    v2 SMALLINT DEFAULT "10",
    create_time datetime default current_timestamp(0) on update current_timestamp(0) comment '时间'
)
UNIQUE KEY(k1, k2)
DISTRIBUTED BY HASH (k1, k2) BUCKETS 1;

alter table dws.table_hash
add column update_time datetime default current_timestamp(0) on update current_timestamp(0) comment '更新时间' after create_time;
```

## 测试截图
<img width="761" alt="d01efceb65864984f1f17b23ed933a6" src="https://github.com/user-attachments/assets/5631d539-63e6-4d51-b6f1-6dfb91c3a74d">
<img width="822" alt="9a2427d00f3adc97844307d9c4110b5" src="https://github.com/user-attachments/assets/1041dd10-520a-45d2-9524-0a9b2cac2357">

